### PR TITLE
feat: add reset database option

### DIFF
--- a/gerenciador_livros (13).html
+++ b/gerenciador_livros (13).html
@@ -536,7 +536,20 @@
         <select onchange="localStorage.setItem('desafio',this.value); navegar('dashboard')">
           ${opts}
         </select>
+        <button class="primary" onclick="reiniciarBaseDados()">Reiniciar base de Dados</button>
       </div>`;
+    }
+
+    function reiniciarBaseDados() {
+      if (confirm('Deseja realmente apagar todos os dados?')) {
+        localStorage.clear();
+        livros = [];
+        metaAnnual = [];
+        metaAnnualCount = 0;
+        viewMode = 'list';
+        document.documentElement.setAttribute('data-theme', 'light');
+        navegar('dashboard');
+      }
     }
 
     function adicionarLivro() {


### PR DESCRIPTION
## Summary
- add reset database button to configuration page
- implement function to clear stored data and return to dashboard

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689760315ac88323993c16f0c785b88d