### PR TITLE
Add book type selection to new book form

### DIFF
--- a/gerenciador_livros (13).html
+++ b/gerenciador_livros (13).html
@@ -476,7 +476,9 @@
         if (viewMode === 'list') div.classList.add('list');
         div.onclick = () => mostrarHistorico(b.id);
         const cover = b.capa ? `<img src="${b.capa}" alt="Capa de ${b.titulo}">` : '';
-        const tipo = b.tipo ? `<p>Tipo: ${b.tipo}</p>` : '';
+        const tipo = b.tipo
+          ? `<p>Tipo: ${b.tipo}</p>`
+          : `<button class="update-btn" onclick="event.stopPropagation();editarTipo(${b.id});">Definir tipo</button>`;
         div.innerHTML = `
           ${cover}
           <div class="details">
@@ -509,6 +511,7 @@
       else sorted.forEach(h => html += `<div class="history-item">${h.date}: ${h.pages} pág (${h.percent}%)</div>`);
       html += `<button class="update-btn" onclick="showModal(${id});event.stopPropagation();">Atualizar progresso</button>`;
       html += `<button class="update-btn" onclick="editarCapa(${id});event.stopPropagation();">${book.capa ? 'Editar capa' : 'Adicionar capa'}</button>`;
+      html += `<button class="update-btn" onclick="editarTipo(${id});event.stopPropagation();">${book.tipo ? 'Editar tipo' : 'Adicionar tipo'}</button>`;
       html += `
             </div>
           </div>
@@ -589,6 +592,18 @@
       const url = prompt('URL da capa', book.capa || '');
       if (url !== null) {
         book.capa = url.trim();
+        salvarLivros();
+        navegar('biblioteca');
+      }
+    }
+
+    function editarTipo(id) {
+      const book = livros.find(b => b.id === id);
+      const tp = prompt('Tipo do livro (Físico, E-book, Audiobook)', book.tipo || '');
+      if (tp !== null) {
+        const tipos = ['Físico', 'E-book', 'Audiobook'];
+        if (!tipos.includes(tp)) { alert('Tipo inválido'); return; }
+        book.tipo = tp;
         salvarLivros();
         navegar('biblioteca');
       }

--- a/gerenciador_livros (13).html
+++ b/gerenciador_livros (13).html
@@ -57,6 +57,8 @@
     #slot-view { font-size:1rem; margin-bottom:0.8rem; }
     #slot-remove { position:absolute; bottom:0.5rem; right:0.5rem; font-size:0.8rem; }
     #slot-options button:hover { opacity:0.7; }
+    #type-overlay { position:fixed; top:0; left:0; width:100vw; height:100vh; background:rgba(0,0,0,0.4); display:none; align-items:center; justify-content:center; }
+    #type-editor { background:var(--card-bg); padding:0.5rem; border-radius:0.25rem; width:200px; box-shadow:0 2px 8px var(--card-shadow); }
     .goal-count { display:flex; align-items:center; gap:0.5rem; }
     .goal-count input { width:60px; margin:0; }
     .year-select { width:auto; margin-right:0.5rem; }
@@ -105,6 +107,18 @@
       <button id="slot-remove" title="Remover">🗑️</button>
     </div>
   </div>
+  <div id="type-overlay" onclick="closeTypeEditor()">
+    <div id="type-editor" onclick="event.stopPropagation()">
+      <select id="type-select">
+        <option value="" disabled selected>Tipo</option>
+        <option value="Físico">Físico</option>
+        <option value="E-book">E-book</option>
+        <option value="Audiobook">Audiobook</option>
+      </select>
+      <button class="primary" onclick="saveType()">Salvar</button>
+      <button onclick="closeTypeEditor()" style="background:transparent;color:var(--text-color);padding:0.3rem;width:100%">X</button>
+    </div>
+  </div>
   <script>
     const desafios = [
       { id:'bookmark_sprint', name:'Bookmark Sprint', description:'Ler 15 pág/dia', pagesPerDay:15 },
@@ -124,6 +138,8 @@
     document.getElementById('book-search').addEventListener('input', e => renderBookList(e.target.value));
     let selectedYear = new Date().getFullYear();
     let selectedTab = 'lendo';
+    let editingTypeId = null;
+    let typeBack = 'biblioteca';
 
     function salvarLivros() { localStorage.setItem('livros', JSON.stringify(livros)); }
     function migrateBooksForNewYear() {
@@ -511,7 +527,7 @@
       else sorted.forEach(h => html += `<div class="history-item">${h.date}: ${h.pages} pág (${h.percent}%)</div>`);
       html += `<button class="update-btn" onclick="showModal(${id});event.stopPropagation();">Atualizar progresso</button>`;
       html += `<button class="update-btn" onclick="editarCapa(${id});event.stopPropagation();">${book.capa ? 'Editar capa' : 'Adicionar capa'}</button>`;
-      html += `<button class="update-btn" onclick="editarTipo(${id});event.stopPropagation();">${book.tipo ? 'Editar tipo' : 'Adicionar tipo'}</button>`;
+      html += `<button class="update-btn" onclick="event.stopPropagation();editarTipo(${id}, '${back}');">${book.tipo ? 'Editar tipo' : 'Adicionar tipo'}</button>`;
       html += `
             </div>
           </div>
@@ -597,16 +613,30 @@
       }
     }
 
-    function editarTipo(id) {
+    function editarTipo(id, back = 'biblioteca') {
+      editingTypeId = id;
+      typeBack = back;
       const book = livros.find(b => b.id === id);
-      const tp = prompt('Tipo do livro (Físico, E-book, Audiobook)', book.tipo || '');
-      if (tp !== null) {
-        const tipos = ['Físico', 'E-book', 'Audiobook'];
-        if (!tipos.includes(tp)) { alert('Tipo inválido'); return; }
-        book.tipo = tp;
-        salvarLivros();
-        navegar('biblioteca');
-      }
+      const select = document.getElementById('type-select');
+      select.value = book.tipo || '';
+      document.getElementById('type-overlay').style.display = 'flex';
+    }
+
+    function saveType() {
+      const tp = document.getElementById('type-select').value;
+      if (!tp) { alert('Selecione um tipo'); return; }
+      const book = livros.find(b => b.id === editingTypeId);
+      book.tipo = tp;
+      salvarLivros();
+      closeTypeEditor();
+      navegar(typeBack);
+    }
+
+    function closeTypeEditor() {
+      document.getElementById('type-overlay').style.display = 'none';
+      document.getElementById('type-select').value = '';
+      editingTypeId = null;
+      typeBack = 'biblioteca';
     }
 
     navegar('dashboard');

--- a/gerenciador_livros (13).html
+++ b/gerenciador_livros (13).html
@@ -280,6 +280,7 @@
               ${cover}
               <strong>${b.titulo}</strong>
               <div>${b.lidas}/${b.paginas} (${pc}%)</div>
+              ${b.tipo ? `<div>${b.tipo}</div>` : ''}
               <div class="progress-bar"><div class="progress-fill" style="width:${pc}%"></div></div>
               <button class="update-btn" onclick="event.stopPropagation();showModal(${b.id});">Atualizar</button>
             </div>
@@ -475,12 +476,14 @@
         if (viewMode === 'list') div.classList.add('list');
         div.onclick = () => mostrarHistorico(b.id);
         const cover = b.capa ? `<img src="${b.capa}" alt="Capa de ${b.titulo}">` : '';
+        const tipo = b.tipo ? `<p>Tipo: ${b.tipo}</p>` : '';
         div.innerHTML = `
           ${cover}
           <div class="details">
             <h3>${b.titulo}</h3>
             <p>${b.lidas}/${b.paginas} (${pc}%)</p>
             <div class="progress-bar"><div class="progress-fill" style="width:${pc}%"></div></div>
+            ${tipo}
             <button class="update-btn" onclick="event.stopPropagation();showModal(${b.id});">Atualizar progresso</button>
           </div>
         `;
@@ -499,6 +502,7 @@
             ${cover}
             <div class="history-details">
               <h2>Histórico: ${book.titulo}</h2>
+              ${book.tipo ? `<p><strong>Tipo:</strong> ${book.tipo}</p>` : ''}
       `;
       const sorted = book.history.slice().sort((a,b) => b.timestamp - a.timestamp);
       if (!sorted.length) html += '<p>Nenhum progresso registrado.</p>';
@@ -520,6 +524,12 @@
           <input id="capa" placeholder="URL da capa" />
           <input id="paginas" type="number" placeholder="Páginas" />
           <input id="lidas" type="number" placeholder="Lidas" />
+          <select id="tipo">
+            <option value="" disabled selected>Tipo</option>
+            <option value="Físico">Físico</option>
+            <option value="E-book">E-book</option>
+            <option value="Audiobook">Audiobook</option>
+          </select>
           <button class="primary" onclick="adicionarLivro()">Salvar</button>
         </div>`;
     }
@@ -557,12 +567,13 @@
       const c = document.getElementById('capa').value;
       const pg = parseInt(document.getElementById('paginas').value);
       const ld = parseInt(document.getElementById('lidas').value);
-      if (!t || !pg || isNaN(ld)) return alert('Preencha todos os campos!');
+      const tp = document.getElementById('tipo').value;
+      if (!t || !pg || isNaN(ld) || !tp) return alert('Preencha todos os campos!');
       const cy = new Date().getFullYear();
       let status = 'quero_ler', year = cy, completedYear = null;
       if (ld >= pg) { status = 'lido'; completedYear = cy; }
       else if (ld > 0) { status = 'lendo'; }
-      const book = { id: Date.now(), titulo: t, paginas: pg, lidas: ld, capa: c, history: [], status, year, completedYear };
+      const book = { id: Date.now(), titulo: t, paginas: pg, lidas: ld, capa: c, tipo: tp, history: [], status, year, completedYear };
       if (ld > 0) {
         const date = new Date().toISOString().split('T')[0];
         const pct  = Math.round((ld/pg)*100);


### PR DESCRIPTION
## Summary
- allow selecting book type (Físico, E-book, Audiobook) when adding a book
- persist and display chosen type in book listings, history, and dashboard cards

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68977bdd063c83239ae1285c813d6b0b