### PR TITLE
Atualiza progresso diário do dashboard

### DIFF
--- a/gerenciador_livros (13).html
+++ b/gerenciador_livros (13).html
@@ -120,8 +120,17 @@
     let viewMode = localStorage.getItem('viewMode') || 'list';
     const conteudo = document.getElementById('conteudo');
     document.getElementById('today').textContent = new Date().toLocaleDateString();
+    let currentDate = new Date().toISOString().split('T')[0];
     if (localStorage.getItem('tema')) document.documentElement.setAttribute('data-theme', localStorage.getItem('tema'));
     document.getElementById('book-search').addEventListener('input', e => renderBookList(e.target.value));
+    setInterval(() => {
+      const todayStr = new Date().toISOString().split('T')[0];
+      if (todayStr !== currentDate) {
+        currentDate = todayStr;
+        document.getElementById('today').textContent = new Date().toLocaleDateString();
+        if (document.getElementById('tituloPagina').textContent === 'Dashboard') carregarDashboard();
+      }
+    }, 60 * 1000);
     let selectedYear = new Date().getFullYear();
     let selectedTab = 'lendo';
 


### PR DESCRIPTION
## Resumo
- atualiza automaticamente a data exibida no topo
- recarrega o dashboard quando o dia muda para refletir o progresso diário

## Testes
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68977d1ef744832396d7b01bca86948c