### PR TITLE
Enhance reading progress modal UX

### DIFF
--- a/gerenciador_livros (13).html
+++ b/gerenciador_livros (13).html
@@ -91,6 +91,7 @@
       <input type="date" id="modal-date" />
       <select id="modal-type"><option value="pages">Páginas</option><option value="percent">%</option></select>
       <input type="number" id="modal-value" placeholder="Valor" />
+      <div id="modal-progress" style="margin:0.5rem 0;"></div>
       <button id="modal-save" class="primary">OK</button>
       <button onclick="hideModal()" style="background:transparent;color:var(--text-color);padding:0.3rem;width:100%">X</button>
     </div>
@@ -174,14 +175,24 @@
     let currentEditId = null;
     function showModal(id) {
       currentEditId = id;
+      const book = livros.find(b => b.id === id);
       document.getElementById('modal-date').value = new Date().toISOString().split('T')[0];
       document.getElementById('modal-type').value = 'pages';
-      document.getElementById('modal-value').value = '';
+      const valueInput = document.getElementById('modal-value');
+      valueInput.value = '';
+      const pct = Math.round((book.lidas / book.paginas) * 100);
+      document.getElementById('modal-progress').textContent = `${book.lidas}/${book.paginas} (${pct}%)`;
       document.getElementById('modal-overlay').style.display = 'flex';
+      valueInput.focus();
+      valueInput.select();
     }
-    function hideModal() { document.getElementById('modal-overlay').style.display = 'none'; currentEditId = null; }
+    function hideModal() {
+      document.getElementById('modal-overlay').style.display = 'none';
+      currentEditId = null;
+      document.getElementById('modal-progress').textContent = '';
+    }
 
-    document.getElementById('modal-save').addEventListener('click', () => {
+    function saveModal() {
       const date = document.getElementById('modal-date').value;
       const type = document.getElementById('modal-type').value;
       const val = parseFloat(document.getElementById('modal-value').value);
@@ -205,7 +216,10 @@
         book.year = new Date().getFullYear();
       }
       salvarLivros(); hideModal(); navegar('biblioteca');
-    });
+    }
+
+    document.getElementById('modal-save').addEventListener('click', saveModal);
+    document.getElementById('modal-value').addEventListener('keydown', e => { if (e.key === 'Enter') saveModal(); });
 
     function carregarDashboard() {
       const hoje = new Date();


### PR DESCRIPTION
## Summary
- Auto-focus and select value field when updating reading progress
- Show current page progress and percentage in progress modal
- Allow saving reading progress via Enter key

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689780e86f6c83238134106932c716fb