### PR TITLE
Fix duplicate book selection in annual goal

### DIFF
--- a/gerenciador_livros (13).html
+++ b/gerenciador_livros (13).html
@@ -415,7 +415,9 @@
     }
 
     function renderBookList(term) {
-      const list = livros.filter(b => b.titulo.toLowerCase().includes(term.toLowerCase()));
+      const list = livros
+        .filter(b => b.titulo.toLowerCase().includes(term.toLowerCase()))
+        .filter(b => !metaAnnual.includes(b.id));
       document.getElementById('book-list').innerHTML = list.map(b => `<div class="book-option" onclick="chooseBook(${b.id})">${b.titulo}</div>`).join('');
     }
 


### PR DESCRIPTION
## Summary
- hide already selected books in annual goal selector

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68978675e5d48323acd640636d6adc82