### PR TITLE
feat: add charts to reports page

### DIFF
--- a/gerenciador_livros (13).html
+++ b/gerenciador_livros (13).html
@@ -67,7 +67,10 @@
     .tab.active { background:var(--nav-bg); color:#fff; }
     .dashboard-columns { display:grid; grid-template-columns:1fr 1fr; gap:1rem; }
     .dashboard-left, .dashboard-right { display:flex; flex-direction:column; gap:1rem; }
+    .report-grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(300px,1fr)); gap:1rem; }
+    .report-grid canvas { width:100% !important; height:auto !important; }
   </style>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body>
   <nav>
@@ -598,7 +601,59 @@
     }
 
     function carregarRelatorios() {
-      conteudo.innerHTML = `<div class="card"><h2>Relatórios</h2><p>Em breve</p></div>`;
+      const statusCounts = { quero_ler:0, lendo:0, lido:0 };
+      livros.forEach(b => { statusCounts[b.status] = (statusCounts[b.status] || 0) + 1; });
+
+      const typeCounts = {};
+      livros.forEach(b => { const t = b.tipo || 'Sem tipo'; typeCounts[t] = (typeCounts[t] || 0) + 1; });
+
+      const historyByMonth = {};
+      livros.forEach(b => b.history.forEach(h => {
+        const m = h.date.slice(0,7);
+        historyByMonth[m] = (historyByMonth[m] || 0) + h.delta;
+      }));
+      const months = Object.keys(historyByMonth).sort();
+      const pagesData = months.map(m => historyByMonth[m]);
+      const labels = months.map(m => { const [y,mo] = m.split('-'); return `${mo}/${y}`; });
+
+      conteudo.innerHTML = `
+        <div class="card">
+          <h2>Relatórios</h2>
+          <div class="report-grid">
+            <canvas id="statusChart"></canvas>
+            <canvas id="typeChart"></canvas>
+            <canvas id="pagesChart" style="grid-column:1/-1"></canvas>
+          </div>
+        </div>`;
+
+      const baseColor = getComputedStyle(document.documentElement).getPropertyValue('--text-color');
+      Chart.defaults.color = baseColor;
+
+      new Chart(document.getElementById('statusChart'), {
+        type:'doughnut',
+        data:{
+          labels:['Quero ler','Lendo','Lido'],
+          datasets:[{ data:[statusCounts.quero_ler, statusCounts.lendo, statusCounts.lido], backgroundColor:['#f59e0b','#3b82f6','#22c55e'] }]
+        }
+      });
+
+      new Chart(document.getElementById('typeChart'), {
+        type:'bar',
+        data:{
+          labels:Object.keys(typeCounts),
+          datasets:[{ data:Object.values(typeCounts), backgroundColor:'#3b82f6' }]
+        },
+        options:{ plugins:{ legend:{ display:false } }, scales:{ y:{ beginAtZero:true } } }
+      });
+
+      new Chart(document.getElementById('pagesChart'), {
+        type:'line',
+        data:{
+          labels,
+          datasets:[{ label:'Páginas lidas', data:pagesData, borderColor:'#22c55e', tension:0.3 }]
+        },
+        options:{ scales:{ y:{ beginAtZero:true } } }
+      });
     }
 
     function carregarConfiguracoes() {


### PR DESCRIPTION
## Summary
- add Chart.js and styling for responsive report grid
- implement report tab with status, type, and monthly pages charts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68978bafb5408323bd7eca6b31357e0b