### PR TITLE
feat: add ISBN lookup

### DIFF
--- a/gerenciador_livros (13).html
+++ b/gerenciador_livros (13).html
@@ -566,6 +566,9 @@
             ${cover}
             <div class="history-details">
               <h2>Histórico: ${book.titulo}</h2>
+              ${book.autor ? `<p><strong>Autor:</strong> ${book.autor}</p>` : ''}
+              ${book.editora ? `<p><strong>Editora:</strong> ${book.editora}</p>` : ''}
+              ${book.isbn ? `<p><strong>ISBN:</strong> ${book.isbn}</p>` : ''}
               ${book.tipo ? `<p><strong>Tipo:</strong> ${book.tipo}</p>` : ''}
       `;
       const sorted = book.history.slice().sort((a,b) => b.timestamp - a.timestamp);
@@ -585,7 +588,11 @@
       conteudo.innerHTML = `
         <div class="card">
           <h2>Adicionar Livro</h2>
+          <input id="isbn" placeholder="ISBN" />
+          <button class="update-btn" onclick="buscarISBN()">Buscar</button>
           <input id="titulo" placeholder="Título" />
+          <input id="autor" placeholder="Autor" />
+          <input id="editora" placeholder="Editora" />
           <input id="capa" placeholder="URL da capa" />
           <input id="paginas" type="number" placeholder="Páginas" />
           <input id="lidas" type="number" placeholder="Lidas" />
@@ -597,6 +604,24 @@
           </select>
           <button class="primary" onclick="adicionarLivro()">Salvar</button>
         </div>`;
+    }
+
+    async function buscarISBN() {
+      const isbn = document.getElementById('isbn').value.trim();
+      if (!isbn) { alert('Informe o ISBN'); return; }
+      try {
+        const resp = await fetch(`https://www.googleapis.com/books/v1/volumes?q=isbn:${isbn}`);
+        const data = await resp.json();
+        if (!data.items || data.totalItems === 0) { alert('Livro não encontrado'); return; }
+        const info = data.items[0].volumeInfo;
+        document.getElementById('titulo').value = info.title || '';
+        document.getElementById('autor').value = info.authors ? info.authors.join(', ') : '';
+        document.getElementById('editora').value = info.publisher || '';
+        document.getElementById('capa').value = (info.imageLinks && (info.imageLinks.thumbnail || info.imageLinks.smallThumbnail)) || '';
+        document.getElementById('paginas').value = info.pageCount || '';
+      } catch (e) {
+        alert('Erro ao buscar ISBN');
+      }
     }
 
     function carregarRelatorios() {
@@ -628,7 +653,10 @@
     }
 
     function adicionarLivro() {
+      const isbn = document.getElementById('isbn').value;
       const t = document.getElementById('titulo').value;
+      const a = document.getElementById('autor').value;
+      const e = document.getElementById('editora').value;
       const c = document.getElementById('capa').value;
       const pg = parseInt(document.getElementById('paginas').value);
       const ld = parseInt(document.getElementById('lidas').value);
@@ -638,7 +666,7 @@
       let status = 'quero_ler', year = cy, completedYear = null;
       if (ld >= pg) { status = 'lido'; completedYear = cy; }
       else if (ld > 0) { status = 'lendo'; }
-      const book = { id: Date.now(), titulo: t, paginas: pg, lidas: ld, capa: c, tipo: tp, history: [], status, year, completedYear };
+      const book = { id: Date.now(), titulo: t, autor: a, editora: e, isbn, paginas: pg, lidas: ld, capa: c, tipo: tp, history: [], status, year, completedYear };
       if (ld > 0) {
         const date = new Date().toISOString().split('T')[0];
         const pct  = Math.round((ld/pg)*100);


### PR DESCRIPTION
## Summary
- allow adding books by ISBN with automatic lookup
- store author, publisher and ISBN when saving books
- show fetched metadata in the book history view

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897938c668083238177a06521be0e0e