### PR TITLE
Exibir data de início de leitura na biblioteca

### DIFF
--- a/gerenciador_livros (13).html
+++ b/gerenciador_livros (13).html
@@ -162,6 +162,10 @@
     let typeBack = 'biblioteca';
 
     function salvarLivros() { localStorage.setItem('livros', JSON.stringify(livros)); }
+    function formatDate(dateStr) {
+      const [year, month, day] = dateStr.split('-');
+      return `${day}/${month}/${year.slice(2)}`;
+    }
     function migrateBooksForNewYear() {
       const cy = new Date().getFullYear();
       livros.forEach(b => {
@@ -551,7 +555,7 @@
         const cover = b.capa
           ? `<img src="${b.capa}" alt="Capa de ${b.titulo}">`
           : `<div class="cover-placeholder">${b.titulo}</div>`;
-        const start = b.startDate ? `<p>Início: ${b.startDate}</p>` : '';
+        const start = b.startDate ? `<p>Início: ${formatDate(b.startDate)}</p>` : '';
         const tipo = b.tipo
           ? `<p>Tipo: ${b.tipo}</p>`
           : `<button class="update-btn" onclick="event.stopPropagation();editarTipo(${b.id});">Definir tipo</button>`;
@@ -560,8 +564,8 @@
           <div class="details">
             <p>${b.lidas}/${b.paginas} (${pc}%)</p>
             <div class="progress-bar"><div class="progress-fill" style="width:${pc}%"></div></div>
-            ${start}
             ${tipo}
+            ${start}
             <button class="update-btn" onclick="event.stopPropagation();showModal(${b.id});">Atualizar progresso</button>
           </div>
         `;

--- a/gerenciador_livros (13).html
+++ b/gerenciador_livros (13).html
@@ -134,7 +134,11 @@
       { id:'annual_challenge', name:'Desafio Anual', description:'Leia 20 livros até o final do ano!', pagesPerDay:17 }
     ];
     let livros = JSON.parse(localStorage.getItem('livros')) || [];
-    livros = livros.map(b => ({ ...b, history: b.history || [], resumo: b.resumo || '' }));
+    livros = livros.map(b => {
+      const history = b.history || [];
+      const startDate = b.startDate || (history.length ? history[0].date : null);
+      return { ...b, history, resumo: b.resumo || '', startDate };
+    });
     let metaAnnual = JSON.parse(localStorage.getItem('metaAnnual')) || [];
     let metaAnnualCount = parseInt(localStorage.getItem('metaAnnualCount')) || metaAnnual.length;
     let selectingSlot = null;
@@ -223,6 +227,11 @@
       const delta = np - old;
       const pct = Math.round((np / book.paginas) * 100);
       book.lidas = Math.min(np, book.paginas);
+      if (book.lidas > 0 && !book.startDate) {
+        book.startDate = date;
+      } else if (book.lidas === 0) {
+        book.startDate = null;
+      }
       book.history.push({ date, pages: book.lidas, percent: pct, delta, timestamp: Date.now() });
       if (book.lidas >= book.paginas) {
         book.status = 'lido';
@@ -542,6 +551,7 @@
         const cover = b.capa
           ? `<img src="${b.capa}" alt="Capa de ${b.titulo}">`
           : `<div class="cover-placeholder">${b.titulo}</div>`;
+        const start = b.startDate ? `<p>Início: ${b.startDate}</p>` : '';
         const tipo = b.tipo
           ? `<p>Tipo: ${b.tipo}</p>`
           : `<button class="update-btn" onclick="event.stopPropagation();editarTipo(${b.id});">Definir tipo</button>`;
@@ -550,6 +560,7 @@
           <div class="details">
             <p>${b.lidas}/${b.paginas} (${pc}%)</p>
             <div class="progress-bar"><div class="progress-fill" style="width:${pc}%"></div></div>
+            ${start}
             ${tipo}
             <button class="update-btn" onclick="event.stopPropagation();showModal(${b.id});">Atualizar progresso</button>
           </div>
@@ -680,11 +691,12 @@
       let status = 'quero_ler', year = cy, completedYear = null;
       if (ld >= pg) { status = 'lido'; completedYear = cy; }
       else if (ld > 0) { status = 'lendo'; }
-      const book = { id: Date.now(), titulo: t, autor: a, editora: e, resumo: r, isbn, paginas: pg, lidas: ld, capa: c, tipo: tp, history: [], status, year, completedYear };
+      const book = { id: Date.now(), titulo: t, autor: a, editora: e, resumo: r, isbn, paginas: pg, lidas: ld, capa: c, tipo: tp, history: [], status, year, completedYear, startDate: null };
       if (ld > 0) {
         const date = new Date().toISOString().split('T')[0];
         const pct  = Math.round((ld/pg)*100);
         book.history.push({ date, pages: ld, percent: pct, delta: ld, timestamp: Date.now() });
+        book.startDate = date;
       }
       livros.push(book);
       salvarLivros();

--- a/gerenciador_livros (13).html
+++ b/gerenciador_livros (13).html
@@ -137,7 +137,8 @@
     livros = livros.map(b => {
       const history = b.history || [];
       const startDate = b.startDate || (history.length ? history[0].date : null);
-      return { ...b, history, resumo: b.resumo || '', startDate };
+      const endDate = b.endDate || (b.status === 'lido' && history.length ? history[history.length - 1].date : null);
+      return { ...b, history, resumo: b.resumo || '', startDate, endDate };
     });
     let metaAnnual = JSON.parse(localStorage.getItem('metaAnnual')) || [];
     let metaAnnualCount = parseInt(localStorage.getItem('metaAnnualCount')) || metaAnnual.length;
@@ -241,12 +242,15 @@
         book.status = 'lido';
         book.completedYear = new Date().getFullYear();
         book.lidas = book.paginas;
+        book.endDate = book.endDate || date;
       } else if (book.lidas > 0) {
         book.status = 'lendo';
         book.year = new Date().getFullYear();
+        book.endDate = null;
       } else {
         book.status = 'quero_ler';
         book.year = new Date().getFullYear();
+        book.endDate = null;
       }
       salvarLivros(); hideModal(); navegar('biblioteca');
     }
@@ -556,6 +560,7 @@
           ? `<img src="${b.capa}" alt="Capa de ${b.titulo}">`
           : `<div class="cover-placeholder">${b.titulo}</div>`;
         const start = b.startDate ? `<p>Início: ${formatDate(b.startDate)}</p>` : '';
+        const end = b.endDate ? `<p>Fim: ${formatDate(b.endDate)}</p>` : '';
         const tipo = b.tipo
           ? `<p>Tipo: ${b.tipo}</p>`
           : `<button class="update-btn" onclick="event.stopPropagation();editarTipo(${b.id});">Definir tipo</button>`;
@@ -566,6 +571,7 @@
             <div class="progress-bar"><div class="progress-fill" style="width:${pc}%"></div></div>
             ${tipo}
             ${start}
+            ${end}
             <button class="update-btn" onclick="event.stopPropagation();showModal(${b.id});">Atualizar progresso</button>
           </div>
         `;
@@ -589,6 +595,8 @@
                 ${book.editora ? `<p><strong>Editora:</strong> ${book.editora}</p>` : ''}
                 ${book.isbn ? `<p><strong>ISBN:</strong> ${book.isbn}</p>` : ''}
                 ${book.tipo ? `<p><strong>Tipo:</strong> ${book.tipo}</p>` : ''}
+                ${book.startDate ? `<p><strong>Início:</strong> ${formatDate(book.startDate)}</p>` : ''}
+                ${book.endDate ? `<p><strong>Fim:</strong> ${formatDate(book.endDate)}</p>` : ''}
               </div>
             </div>
             <div class="history-synopsis">
@@ -695,12 +703,13 @@
       let status = 'quero_ler', year = cy, completedYear = null;
       if (ld >= pg) { status = 'lido'; completedYear = cy; }
       else if (ld > 0) { status = 'lendo'; }
-      const book = { id: Date.now(), titulo: t, autor: a, editora: e, resumo: r, isbn, paginas: pg, lidas: ld, capa: c, tipo: tp, history: [], status, year, completedYear, startDate: null };
+      const book = { id: Date.now(), titulo: t, autor: a, editora: e, resumo: r, isbn, paginas: pg, lidas: ld, capa: c, tipo: tp, history: [], status, year, completedYear, startDate: null, endDate: null };
       if (ld > 0) {
         const date = new Date().toISOString().split('T')[0];
         const pct  = Math.round((ld/pg)*100);
         book.history.push({ date, pages: ld, percent: pct, delta: ld, timestamp: Date.now() });
         book.startDate = date;
+        if (ld >= pg) book.endDate = date;
       }
       livros.push(book);
       salvarLivros();


### PR DESCRIPTION
## Resumo
- Adiciona persistência da data em que a leitura de cada livro começou
- Mostra a data de início de leitura nos cartões da biblioteca

## Testes
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897b2eb107c8323972c46f6d0856a1b