### PR TITLE
Align history back button to left

### DIFF
--- a/gerenciador_livros (13).html
+++ b/gerenciador_livros (13).html
@@ -564,7 +564,7 @@
       const cover = book.capa ? `<img src="${book.capa}" alt="Capa de ${book.titulo}">` : '';
       let html = `
         <div class="card">
-          <button onclick="navegar('${back}')" style="background:transparent;color:var(--text-color);border:none;margin-bottom:1rem">◀ Voltar</button>
+          <button onclick="navegar('${back}')" style="background:transparent;color:var(--text-color);border:none;margin-bottom:1rem;display:block;width:auto;padding:0;text-align:left">◀ Voltar</button>
           <div class="history-layout">
             <div class="history-info">
               ${cover}


### PR DESCRIPTION
## Summary
- Left-align history page's back button for improved navigation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897b394e028832399f6f0610fd861ab