### PR TITLE
Corrige exibição da meta diária no dashboard

### DIFF
--- a/gerenciador_livros (13).html
+++ b/gerenciador_livros (13).html
@@ -156,11 +156,11 @@
   </div>
   <script>
     const desafios = [
-      { id:'bookmark_sprint', name:'Bookmark Sprint', description:'Ler 15 pág/dia', pagesPerDay:15 },
-      { id:'reading_marathon', name:'Reading Marathon', description:'Ler 30 pág/dia', pagesPerDay:30 },
-      { id:'weekend_warrior', name:'Weekend Warrior', description:'Ler 50 pág/dia', pagesPerDay:50 },
-      { id:'annual_challenge', name:'Desafio Anual', description:'Leia 20 livros até o final do ano!', pagesPerDay:17 }
-    ];
+      { id:'bookmark_sprint', name:'Bookmark Sprint', pagesPerDay:15 },
+      { id:'reading_marathon', name:'Reading Marathon', pagesPerDay:30 },
+      { id:'weekend_warrior', name:'Weekend Warrior', pagesPerDay:50 },
+      { id:'annual_challenge', name:'Desafio Anual', pagesPerDay:17 }
+    ].map(d => ({ ...d, description: `Ler ${d.pagesPerDay} pág/dia` }));
     let livros = JSON.parse(localStorage.getItem('livros')) || [];
     livros = livros.map(b => {
       const history = b.history || [];


### PR DESCRIPTION
### Resumo
- Corrige texto da meta diária para mostrar número de páginas por dia em todos os desafios

### Testes
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4d11320a48323b6ae53f24c3f98b0