### PR TITLE
feat: show daily progress in meta card

### DIFF
--- a/gerenciador_livros (13).html
+++ b/gerenciador_livros (13).html
@@ -395,7 +395,7 @@
           <h2>Meta diária</h2>
           <p>${d.description}</p>
           <div class=\"progress-bar\"><div class=\"progress-fill\" style=\"width:${pct}%\"></div></div>
-          <p>${pct}% meta</p>
+          <p>${daily}/${dm} pág (${pct}%)</p>
         </div>`;
       const summaryCard = `
         <div class=\"card\">


### PR DESCRIPTION
## Summary
- display daily goal progress as `lidas/meta pág (percent%)`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4dd4ec28883239d978b2361f13e54