### PR TITLE
feat: exibir porcentagem na meta anual

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,6 +91,22 @@
       top:0;
       background:#16A34A;
     }
+    .percent-circle {
+      position:absolute;
+      top:0.25rem;
+      left:0.25rem;
+      width:24px;
+      height:24px;
+      border-radius:50%;
+      background:#FACC15;
+      color:#000;
+      display:flex;
+      align-items:center;
+      justify-content:center;
+      font-size:0.7rem;
+      font-weight:700;
+      z-index:3;
+    }
     .history-layout { display:flex; gap:6rem; align-items:flex-start; }
     .history-layout img { width:120px; height:180px; object-fit:cover; border-radius:0.25rem; }
     .history-info { display:flex; gap:1rem; align-items:flex-start; }
@@ -572,12 +588,14 @@
         if (id) {
           const book = livros.find(b => b.id === id);
           slot.className = 'goal-slot filled';
+          const pc = book ? (book.tipo === 'Audiobook' ? book.lidas : Math.round((book.lidas / book.paginas) * 100)) : 0;
+          const pctCircle = `<div class="percent-circle">${pc}%</div>`;
           const badge = book && book.lidas >= book.paginas ? '<div class="lido-badge">Lido</div>' : '';
           if (book && book.capa) {
-            slot.innerHTML = `${badge}<img src="${book.capa}" alt="${book.titulo}">`;
+            slot.innerHTML = `${pctCircle}${badge}<img src="${book.capa}" alt="${book.titulo}">`;
             slot.style.padding = '0';
           } else {
-            slot.innerHTML = `${badge}${book ? book.titulo : ''}`;
+            slot.innerHTML = `${pctCircle}${badge}${book ? book.titulo : ''}`;
             slot.style.padding = '';
           }
           slot.onclick = () => openSlotOptions(i);

--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@
       margin-bottom:0.5rem;
     }
     .reading-card .progress-bar { width:100%; margin:0.25rem 0; }
-    .reading-card .update-btn { width:100%; margin-top:0.25rem; }
+    .reading-card .update-btn { width:100%; margin-top:0; }
     .meta-badge, .lido-badge {
       position:absolute;
       left:0;
@@ -93,7 +93,7 @@
     }
     .percent-circle {
       position:absolute;
-      top:0.25rem;
+      top:0;
       left:0.25rem;
       width:24px;
       height:24px;

--- a/index.html
+++ b/index.html
@@ -589,8 +589,9 @@
           const book = livros.find(b => b.id === id);
           slot.className = 'goal-slot filled';
           const pc = book ? (book.tipo === 'Audiobook' ? book.lidas : Math.round((book.lidas / book.paginas) * 100)) : 0;
-          const pctCircle = `<div class="percent-circle">${pc}%</div>`;
-          const badge = book && book.lidas >= book.paginas ? '<div class="lido-badge">Lido</div>' : '';
+          const isCompleted = book && book.lidas >= book.paginas;
+          const pctCircle = !isCompleted ? `<div class="percent-circle">${pc}%</div>` : '';
+          const badge = isCompleted ? '<div class="lido-badge">Lido</div>' : '';
           if (book && book.capa) {
             slot.innerHTML = `${pctCircle}${badge}<img src="${book.capa}" alt="${book.titulo}">`;
             slot.style.padding = '0';


### PR DESCRIPTION
## Summary
- show current book progress percentage in a yellow circle on Meta Anual slots

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5228e500c83239bdc65620758eda4