### PR TITLE
Add monochrome icons for book format types

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,6 +157,7 @@
     .calendar-day { width:40px; height:40px; border-radius:50%; display:flex; align-items:center; justify-content:center; background:var(--progress-bg); color:var(--text-color); }
     .calendar-day.read { background:#16A34A; color:#fff; }
     .calendar-day.empty { background:transparent; }
+    .card .details p { display:flex; align-items:center; gap:0.25rem; }
     .type-icon { display:inline-flex; align-items:center; gap:0.25rem; }
     .type-icon .material-symbols-outlined { font-size:1rem; }
   </style>


### PR DESCRIPTION
## Summary
- show book, tablet and headphone icons alongside physical, e-book and audiobook entries
- style icons to align with text and reuse Material Symbols

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a52dc793548323b3f6c30dd6749de3