### PR TITLE
Padroniza exibição do tipo de livro

### DIFF
--- a/index.html
+++ b/index.html
@@ -509,8 +509,8 @@
               ${badge}
               ${cover}
               <div>${progressText}</div>
-              ${b.tipo ? `<div>${renderTipo(b.tipo)}</div>` : ''}
               <div class="progress-bar"><div class="progress-fill" style="width:${pc}%"></div></div>
+              ${b.tipo ? `<div>${renderTipo(b.tipo)}</div>` : ''}
               <button class="update-btn" onclick="event.stopPropagation();showModal(${b.id});">Atualizar</button>
             </div>
           `;


### PR DESCRIPTION
## Resumo
- Move a exibição do tipo de livro para abaixo da barra de progresso no dashboard de leituras

## Testes
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a538fac39083239ca09670f5c32074