### PR TITLE
Corrige atualização da data na dashboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -242,14 +242,19 @@
     let currentDate = getLocalDateISO();
     if (localStorage.getItem('tema')) document.documentElement.setAttribute('data-theme', localStorage.getItem('tema'));
     document.getElementById('book-search').addEventListener('input', e => renderBookList(e.target.value));
-    setInterval(() => {
+    function updateToday() {
       const todayStr = getLocalDateISO();
       if (todayStr !== currentDate) {
         currentDate = todayStr;
         document.getElementById('today').textContent = new Date().toLocaleDateString();
         if (document.getElementById('tituloPagina').textContent === 'Dashboard') carregarDashboard();
       }
-    }, 60 * 1000);
+    }
+    setInterval(updateToday, 60 * 1000);
+    document.addEventListener('visibilitychange', () => {
+      if (!document.hidden) updateToday();
+    });
+    window.addEventListener('focus', updateToday);
     let selectedYear = new Date().getFullYear();
     let selectedTab = 'lendo';
     let groupType = 'none';


### PR DESCRIPTION
## Resumo
- Atualiza o cabeçalho da dashboard quando o dia muda, mesmo após retornar à aba.
- Adiciona ouvintes para `visibilitychange` e `focus` garantindo que as informações sejam recarregadas.

## Testes
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5b7be365c8323bf222b60f8926645